### PR TITLE
set airflow home back to root

### DIFF
--- a/conduit/WebDockerfile
+++ b/conduit/WebDockerfile
@@ -10,7 +10,7 @@ ENV TERM linux
 
 # Airflow
 ARG AIRFLOW_VERSION=1.10.4
-ARG AIRFLOW_HOME=/conduit
+ARG AIRFLOW_HOME=/root
 
 # Define en_US.
 ENV LANGUAGE en_US.UTF-8

--- a/conduit/config/airflow.cfg
+++ b/conduit/config/airflow.cfg
@@ -6,7 +6,7 @@ dags_folder = /conduit/dags
 
 # The folder where airflow should store its log files
 # This path must be absolute
-base_log_folder = /conduit/logs
+base_log_folder = /root/logs
 
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
 # must supply an Airflow connection id that provides access to the storage

--- a/conduit/scripts/entrypoint.sh
+++ b/conduit/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ export \
   AIRFLOW__CORE__LOAD_EXAMPLES \
   AIRFLOW__CORE__SQL_ALCHEMY_CONN \
 
-export AIRFLOW_HOME=/conduit
+export AIRFLOW_HOME=/root
 
 # Load DAGs exemples (default: Yes)
 if [[ -z "$AIRFLOW__CORE__LOAD_EXAMPLES" && "${LOAD_EX:=n}" == n ]]


### PR DESCRIPTION
Since the entrypoint.sh script now sets the environment variables to fill the dagbags, the logs and other airflow files can go back to /root