### PR TITLE
Webserver Hotfix

### DIFF
--- a/WebDockerfile
+++ b/WebDockerfile
@@ -52,6 +52,8 @@ RUN set -ex \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
     && pip install -U pip setuptools wheel \
+    && pip install werkzeug==0.16.0 \
+    && pip install SQLAlchemy==1.3.15 \
     && pip install Cython \
     && pip install pytz \
     && pip install pyOpenSSL \


### PR DESCRIPTION
Pins versions for werkzeug and sqlalchemy, which are recently updated to be incompatible with our docker-airflow container. 

Reference:
https://github.com/puckel/docker-airflow/issues/535